### PR TITLE
Constructors implementation

### DIFF
--- a/src/Core.jl
+++ b/src/Core.jl
@@ -1,6 +1,6 @@
 module Core
 
-export callinstancemethod, callstaticmethod
+export callinstancemethod, callstaticmethod, callconstructor
 
 using JavaCall.JNI
 using JavaCall.Signatures
@@ -143,4 +143,11 @@ for (type, method) in [
     end
     eval(generatemethod(:callstaticmethod, params, body, :N))
 end
+
+function callconstructor(class::jclass, signature::String, args::Vararg{Any, N}) where N
+    # Construct name is always <init> as specified by the JNI reference
+    constructor = JNI.get_method_id(class, "<init>", signature)
+    JNI.new_object_a(class, constructor, jvalue[args...])
+end
+
 end

--- a/src/reflection/Constructors.jl
+++ b/src/reflection/Constructors.jl
@@ -1,0 +1,55 @@
+module Constructors
+
+export classconstructors, ConstructorDescriptor
+
+using JavaCall.JNI
+using JavaCall.Conversions
+using JavaCall.Core
+
+using JavaCall.Reflection: Classes
+
+#=
+Struct to hold information about java constructors
+used to generate constructors that call the jni
+This is not a replacement for java.lang.reflect.Constructor
+as it only stores essential information
+
+paramtypes: List of ClassDescriptor with the parameter
+            types accepted by the constructor
+=#
+struct ConstructorDescriptor
+    paramtypes::Vector{Classes.ClassDescriptor}
+end
+
+function Base.show(io::IO, c::ConstructorDescriptor)
+    print(io, "ConstructorDescriptor{paramtypes: ", c.paramtypes, "}");
+end
+
+function Base.:(==)(x::ConstructorDescriptor, y::ConstructorDescriptor)
+    x.paramtypes == y.paramtypes
+end
+
+function descriptorfromconstructor(constructor::jobject)
+    paramtypes = callinstancemethod(
+        constructor, 
+        :getParameterTypes, 
+        Vector{Symbol("java.lang.Class")}, 
+        [])
+    ConstructorDescriptor(map(
+        Classes.descriptorfromclass, 
+        convert_to_vector(Vector{jclass}, paramtypes)
+    ))
+end
+
+classconstructors(classname::Symbol) = classconstructors(Classes.findclass(classname))
+
+function classconstructors(classdescriptor::Classes.ClassDescriptor)
+    array = convert_to_vector(Vector{jobject}, callinstancemethod(
+        classdescriptor.jniclass, 
+        :getConstructors, 
+        Vector{Symbol("java.lang.reflect.Constructor")}, 
+        []))
+    map(descriptorfromconstructor, array)
+end    
+
+end

--- a/src/reflection/Methods.jl
+++ b/src/reflection/Methods.jl
@@ -62,15 +62,6 @@ function descriptorfrommethod(method::jobject)
         Modifiers.methodmodifiers(method))
 end
 
-# function classmethods(classname::Symbol)
-#     array = convert_to_vector(Vector{jobject}, callinstancemethod(
-#         Classes.findclass(classname).jniclass, 
-#         :getMethods, 
-#         Vector{Symbol("java.lang.reflect.Method")}, 
-#         []))
-#     map(descriptorfrommethod, array)
-# end
-
 classmethods(classname::Symbol) = classmethods(Classes.findclass(classname))
 
 function classmethods(classdescriptor::Classes.ClassDescriptor)

--- a/src/reflection/Reflection.jl
+++ b/src/reflection/Reflection.jl
@@ -6,14 +6,18 @@ export
     # Modifiers.jl
     ModifiersDescriptor,
     # Methods.jl
-    classmethods, isstatic, MethodDescriptor
+    classmethods, isstatic, MethodDescriptor,
+    # Constructors.jl
+    classconstructors, ConstructorDescriptor
 
 include("Classes.jl")
 include("Modifiers.jl")
 include("Methods.jl")
+include("Constructors.jl")
 
 using .Classes
 using .Modifiers
 using .Methods
+using .Constructors
 
 end

--- a/test/javacodegeneration.jl
+++ b/test/javacodegeneration.jl
@@ -7,8 +7,8 @@
         @test @isdefined JObjectImpl
         @test @isdefined JString
         @test @isdefined JStringImpl
-        @test @isdefined equals
-        @test @isdefined to_string
+        @test @isdefined JObject_equals
+        @test @isdefined JObject_to_string
     end
 
     @testset "Test Static Methods" begin
@@ -16,23 +16,48 @@
             eval(JavaCodeGeneration.loadclass(Symbol("java.util.Arrays")))
     
             a = [1, 2, 3, 4, 5]
-            @test 1 == binary_search(a, 2) # Java Indexes at 0
+            @test 1 == JArrays_binary_search(a, 2) # Java Indexes at 0
         end
 
         @testset "Test Dates" begin
             eval(JavaCodeGeneration.loadclass(Symbol("java.time.LocalDate")))
-            a = of(Int32(2000), Int32(1), Int32(1))
-            b = plus_days(a, 1)
-            c = plus_months(b, 1)
-            @test get_year(a) == 2000
-            @test get_year(b) == 2000
-            @test get_year(c) == 2000
-            @test get_month_value(a) == 1
-            @test get_month_value(b) == 1
-            @test get_month_value(c) == 2
-            @test get_day_of_month(a) == 1
-            @test get_day_of_month(b) == 2
-            @test get_day_of_month(c) == 2
+            a = JLocalDate_of(Int32(2000), Int32(1), Int32(1))
+            b = JLocalDate_plus_days(a, 1)
+            c = JLocalDate_plus_months(b, 1)
+            @test JLocalDate_get_year(a) == 2000
+            @test JLocalDate_get_year(b) == 2000
+            @test JLocalDate_get_year(c) == 2000
+            @test JLocalDate_get_month_value(a) == 1
+            @test JLocalDate_get_month_value(b) == 1
+            @test JLocalDate_get_month_value(c) == 2
+            @test JLocalDate_get_day_of_month(a) == 1
+            @test JLocalDate_get_day_of_month(b) == 2
+            @test JLocalDate_get_day_of_month(c) == 2
+        end
+    end
+
+    @testset "Test Constructors" begin
+        eval(JavaCodeGeneration.loadclass(Symbol("java.lang.String")))
+
+        hellochars = ['H', 'e', 'l', 'l', 'o']
+        hello1 = JString(hellochars)
+        hello2 = JString(hello1)
+        
+        @test JString_length(hello1) == 5
+        @test JString_length(hello2) == 5
+
+        for (i, c) in enumerate(hellochars)
+            @test JString_char_at(hello1, Int32(i-1)) == c
+            @test JString_char_at(hello2, Int32(i-1)) == c
+        end
+
+        helloworldchars = ['H', 'e', 'l', 'l', 'o', ' ', 'W', 'o', 'r', 'l', 'd']
+        
+        finalworld = JString(helloworldchars, Int32(5), Int32(6))
+
+        helloworld = JString_concat(hello1, finalworld)
+        for (i, c) in enumerate(helloworldchars)
+            @test JString_char_at(helloworld, Int32(i-1)) == c
         end
     end
 end

--- a/test/reflection.jl
+++ b/test/reflection.jl
@@ -91,4 +91,68 @@
         @test found_format
         @test found_getchars
     end
+
+    @testset "Find Constructors" begin
+        constructors = Reflection.classconstructors(Symbol("java.lang.String"))
+
+        @test length(constructors) > 0 
+        @test_isa constructors Vector{Reflection.ConstructorDescriptor}
+
+        found_bytes = false
+        found_chars = false
+        found_string = false
+        found_builder = false
+
+        # String(byte[] bytes, int offset, int length, Charset charset)
+        bytes = Reflection.ConstructorDescriptor([
+            Reflection.ClassDescriptor(
+                C_NULL, 
+                :(Vector{Int8}), 
+                :jbyteArray, 
+                "[B", 
+                Reflection.ClassDescriptor(C_NULL, :Int8, :jbyte, "B")),
+            Reflection.ClassDescriptor(C_NULL, :Int32, :jint, "I"),
+            Reflection.ClassDescriptor(C_NULL, :Int32, :jint, "I"),
+            Reflection.ClassDescriptor(C_NULL, :JCharset, :jobject, "Ljava/nio/charset/Charset;")
+        ])
+
+        # String(char[] value, int offset, int count)
+        chars = Reflection.ConstructorDescriptor([
+            Reflection.ClassDescriptor(
+                C_NULL, 
+                :(Vector{Char}), 
+                :jcharArray, 
+                "[C", 
+                Reflection.ClassDescriptor(C_NULL, :Char, :jchar, "C")),
+            Reflection.ClassDescriptor(C_NULL, :Int32, :jint, "I"),
+            Reflection.ClassDescriptor(C_NULL, :Int32, :jint, "I")
+        ])
+
+        # String(String original)
+        string = Reflection.ConstructorDescriptor([
+            Reflection.ClassDescriptor(C_NULL, :JString, :jobject, "Ljava/lang/String;")
+        ])
+
+        # String(StringBuilder builder)
+        builder = Reflection.ConstructorDescriptor([
+            Reflection.ClassDescriptor(C_NULL, :JStringBuilder, :jobject, "Ljava/lang/StringBuilder;")
+        ])
+
+        for c in constructors
+            if c == bytes
+                found_bytes = true
+            elseif c == chars
+                found_chars = true
+            elseif c == string
+                found_string = true
+            elseif c == builder
+                found_builder = true
+            end
+        end
+
+        @test found_bytes
+        @test found_chars
+        @test found_string
+        @test found_builder
+    end
 end


### PR DESCRIPTION
* Had to change the naming of method names to \<Julia type\>_\<method name\>, so that length method of String class does no clash with Base.length.
* We may want to change this behaviour in the future but that was not the focus of the branch.